### PR TITLE
Update main.atxt

### DIFF
--- a/doc/BOOK/INT2PROGINATS/CHAP_PROGELEM/main.atxt
+++ b/doc/BOOK/INT2PROGINATS/CHAP_PROGELEM/main.atxt
@@ -87,7 +87,7 @@ ATS: the former is an integer while the latter is a floating point number
 まず整数の算術式(IAE)からはじめましょう:
 #dyncode("1"), #dyncode("~2"), #dyncode("1+2"), #dyncode("1+2*3-4"),
 #dyncode("(1+2)/(3-4)"), などです。
-マイナス記号はATSでは波形符号 (#dyncode("~")) で表わすことに注意してください。
+負の符号はATSではチルダ (#dyncode("~")) で表わすことに注意してください。
 また浮動小数点数もサポートしています。
 浮動小数点数の定数をいくつか挙げてみましょう:
 #dyncode("1.0"), #dyncode("~2.0"), #dyncode("3."), #dyncode("0.12345"),


### PR DESCRIPTION
【提案理由】直前の例1+2*3-4に二項演算子の「マイナス記号」が出てくることから，ATSにおいて~に置き換えられているのは「マイナス記号」全体ではなく，負の数を表す数値リテラルの先頭の負符号に限定されると考えられるため．
